### PR TITLE
add gatk variant eval example data

### DIFF
--- a/data/modules/gatk/ADM1594A12.vcf.varianteval
+++ b/data/modules/gatk/ADM1594A12.vcf.varianteval
@@ -1,0 +1,121 @@
+#:GATKReport.v1.1:9
+#:GATKTable:11:3:%s:%s:%s:%s:%s:%d:%d:%d:%.2f:%d:%.2f:;
+#:GATKTable:CompOverlap:The overlap between eval and comp sites
+CompOverlap  CompRod  EvalRod  JexlExpression  Novelty  nEvalVariants  novelSites  nVariantsAtComp  compRate  nConcordant  concordantRate
+CompOverlap  dbsnp    eval     none            all            4945755     1066579          3879176     78.43      3758482           96.89
+CompOverlap  dbsnp    eval     none            known          3879176           0          3879176    100.00      3758482           96.89
+CompOverlap  dbsnp    eval     none            novel          1066579     1066579                0      0.00            0            0.00
+
+#:GATKTable:30:3:%s:%s:%s:%s:%s:%d:%d:%d:%d:%.8f:%.8f:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%.2e:%.2f:%.2f:%.2e:%.2f:%.2f:;
+#:GATKTable:CountVariants:Counts different classes of variants in the sample
+CountVariants  CompRod  EvalRod  JexlExpression  Novelty  nProcessedLoci  nCalledLoci  nRefLoci  nVariantLoci  variantRate  variantRatePerBp  nSNPs    nMNPs  nInsertions  nDeletions  nComplex  nSymbolic  nMixed  nNoCalls  nHets    nHomRef  nHomVar  nSingletons  nHomDerived  heterozygosity  heterozygosityPerBp  hetHomRatio  indelRate  indelRatePerBp  insertionDeletionRatio
+CountVariants  dbsnp    eval     none            all          3137454505      4945755         0       4945755   0.00157636      634.00000000  3842688  81187       449436      468565     96156          0    7723         0  3045852        0  1899903      2382436            0        9.71e-04              1030.00         1.60   3.23e-04         3093.00                    0.96
+CountVariants  dbsnp    eval     none            known        3137454505      3879176         0       3879176   0.00123641      808.00000000  3281335   4836       275147      268092     49766          0       0         0  2216949        0  1662227      1862293            0        7.07e-04              1415.00         1.33   1.89e-04         5290.00                    1.03
+CountVariants  dbsnp    eval     none            novel        3137454505      1066579         0       1066579   0.00033995     2941.00000000   561353  76351       174289      200473     46390          0    7723         0   828903        0   237676       520143            0        2.64e-04              3785.00         3.49   1.34e-04         7449.00                    0.87
+
+#:GATKTable:7:60:%s:%s:%s:%s:%s:%d:%.2f:;
+#:GATKTable:IndelLengthHistogram:Indel length histogram
+IndelLengthHistogram  CompRod  EvalRod  JexlExpression  Novelty  Length  Freq
+IndelLengthHistogram  dbsnp    eval     none            all         -10  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -9  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -8  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -7  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -6  0.02
+IndelLengthHistogram  dbsnp    eval     none            all          -5  0.02
+IndelLengthHistogram  dbsnp    eval     none            all          -4  0.06
+IndelLengthHistogram  dbsnp    eval     none            all          -3  0.04
+IndelLengthHistogram  dbsnp    eval     none            all          -2  0.09
+IndelLengthHistogram  dbsnp    eval     none            all          -1  0.25
+IndelLengthHistogram  dbsnp    eval     none            all           1  0.25
+IndelLengthHistogram  dbsnp    eval     none            all           2  0.09
+IndelLengthHistogram  dbsnp    eval     none            all           3  0.03
+IndelLengthHistogram  dbsnp    eval     none            all           4  0.05
+IndelLengthHistogram  dbsnp    eval     none            all           5  0.02
+IndelLengthHistogram  dbsnp    eval     none            all           6  0.02
+IndelLengthHistogram  dbsnp    eval     none            all           7  0.01
+IndelLengthHistogram  dbsnp    eval     none            all           8  0.01
+IndelLengthHistogram  dbsnp    eval     none            all           9  0.00
+IndelLengthHistogram  dbsnp    eval     none            all          10  0.01
+IndelLengthHistogram  dbsnp    eval     none            known       -10  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -9  0.00
+IndelLengthHistogram  dbsnp    eval     none            known        -8  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -7  0.00
+IndelLengthHistogram  dbsnp    eval     none            known        -6  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -5  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -4  0.04
+IndelLengthHistogram  dbsnp    eval     none            known        -3  0.03
+IndelLengthHistogram  dbsnp    eval     none            known        -2  0.09
+IndelLengthHistogram  dbsnp    eval     none            known        -1  0.28
+IndelLengthHistogram  dbsnp    eval     none            known         1  0.28
+IndelLengthHistogram  dbsnp    eval     none            known         2  0.09
+IndelLengthHistogram  dbsnp    eval     none            known         3  0.04
+IndelLengthHistogram  dbsnp    eval     none            known         4  0.05
+IndelLengthHistogram  dbsnp    eval     none            known         5  0.01
+IndelLengthHistogram  dbsnp    eval     none            known         6  0.01
+IndelLengthHistogram  dbsnp    eval     none            known         7  0.00
+IndelLengthHistogram  dbsnp    eval     none            known         8  0.01
+IndelLengthHistogram  dbsnp    eval     none            known         9  0.00
+IndelLengthHistogram  dbsnp    eval     none            known        10  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel       -10  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        -9  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        -8  0.02
+IndelLengthHistogram  dbsnp    eval     none            novel        -7  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        -6  0.03
+IndelLengthHistogram  dbsnp    eval     none            novel        -5  0.03
+IndelLengthHistogram  dbsnp    eval     none            novel        -4  0.07
+IndelLengthHistogram  dbsnp    eval     none            novel        -3  0.05
+IndelLengthHistogram  dbsnp    eval     none            novel        -2  0.09
+IndelLengthHistogram  dbsnp    eval     none            novel        -1  0.20
+IndelLengthHistogram  dbsnp    eval     none            novel         1  0.21
+IndelLengthHistogram  dbsnp    eval     none            novel         2  0.09
+IndelLengthHistogram  dbsnp    eval     none            novel         3  0.03
+IndelLengthHistogram  dbsnp    eval     none            novel         4  0.06
+IndelLengthHistogram  dbsnp    eval     none            novel         5  0.02
+IndelLengthHistogram  dbsnp    eval     none            novel         6  0.02
+IndelLengthHistogram  dbsnp    eval     none            novel         7  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel         8  0.02
+IndelLengthHistogram  dbsnp    eval     none            novel         9  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        10  0.01
+
+#:GATKTable:30:3:%s:%s:%s:%s:%s:%d:%d:%d:%d:%d:%s:%s:%s:%s:%s:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:;
+#:GATKTable:IndelSummary:Evaluation summary for indels
+IndelSummary  CompRod  EvalRod  JexlExpression  Novelty  n_SNPs   n_singleton_SNPs  n_indels  n_singleton_indels  n_indels_matching_gold_standard  gold_standard_matching_rate  n_multiallelic_indel_sites  percent_of_sites_with_more_than_2_alleles  SNP_to_indel_ratio  SNP_to_indel_ratio_for_singletons  n_novel_indels  indel_novelty_rate  n_insertions  n_deletions  insertion_to_deletion_ratio  n_large_deletions  n_large_insertions  insertion_to_deletion_ratio_for_large_indels  n_coding_indels_frameshifting  n_coding_indels_in_frame  frameshift_rate_for_coding_indels  SNP_het_to_hom_ratio  indel_het_to_hom_ratio  ratio_of_1_and_2_to_3_bp_insertions  ratio_of_1_and_2_to_3_bp_deletions
+IndelSummary  dbsnp    eval     none            all      3844001           2327891   1074505              716041                           422355                        39.31                       60348                                       5.95                3.58                               3.25          438498               40.81        523210       551295                         0.95              49067               35736                                          0.73                              0                         0                                 NA                  1.54                    1.83                                 9.72                                8.60
+IndelSummary  dbsnp    eval     none            known    3282502           1859525    636007              397658                           333473                        52.43                       43002                                       7.25                5.16                               4.68               0                0.00        322915       313092                         1.03              18011               16472                                          0.91                              0                         0                                 NA                  1.31                    1.49                                10.05                               11.46
+IndelSummary  dbsnp    eval     none            novel     561499            468366    438498              318383                            88882                        20.27                       17346                                       4.12                1.28                               1.47          438498              100.00        200295       238203                         0.84              31056               19264                                          0.62                              0                         0                                 NA                  5.04                    2.51                                 9.14                                5.89
+
+#:GATKTable:13:3:%s:%s:%s:%s:%s:%.2f:%d:%d:%d:%d:%s:%.2f:%.2f:;
+#:GATKTable:MetricsCollection:Metrics Collection
+MetricsCollection  CompRod  EvalRod  JexlExpression  Novelty  concordantRate  nSNPs    nSNPloci  nIndels  nIndelLoci  indelRatio  indelRatioLociBased  tiTvRatio
+MetricsCollection  dbsnp    eval     none            all               96.89  3844001   3842688  1074505     1014157        0.95                 0.96       2.01
+MetricsCollection  dbsnp    eval     none            known             96.89  3282502   3281335   636007      593005        1.03                 1.03       2.06
+MetricsCollection  dbsnp    eval     none            novel              0.00   561499    561353   438498      421152        0.84                 0.87       1.73
+
+#:GATKTable:20:3:%s:%s:%s:%s:%s:%d:%d:%d:%.5f:%.3f:%d:%d:%.5f:%.3f:%d:%d:%.2f:%d:%d:%s:;
+#:GATKTable:MultiallelicSummary:Evaluation summary for multi-allelic variants
+MultiallelicSummary  CompRod  EvalRod  JexlExpression  Novelty  nProcessedLoci  nSNPs    nMultiSNPs  processedMultiSnpRatio  variantMultiSnpRatio  nIndels  nMultiIndels  processedMultiIndelRatio  variantMultiIndelRatio  nTi  nTv   TiTvRatio  knownSNPsPartial  knownSNPsComplete  SNPNoveltyRate
+MultiallelicSummary  dbsnp    eval     none            all          3137454505  3842688        1313                 0.00000                 0.000  1014157         60348                   0.00002                   0.060  854  1772       0.48              1167                  0           11.12
+MultiallelicSummary  dbsnp    eval     none            known        3137454505  3281335        1167                 0.00000                 0.000   593005         43002                   0.00001                   0.073  763  1571       0.49              1167                  0            0.00
+MultiallelicSummary  dbsnp    eval     none            novel        3137454505   561353         146                 0.00000                 0.000   421152         17346                   0.00001                   0.041   91   201       0.45                 0                  0          100.00
+
+#:GATKTable:14:3:%s:%s:%s:%s:%s:%d:%d:%.2f:%d:%d:%.2f:%d:%d:%.2f:;
+#:GATKTable:TiTvVariantEvaluator:Ti/Tv Variant Evaluator
+TiTvVariantEvaluator  CompRod  EvalRod  JexlExpression  Novelty  nTi      nTv      tiTvRatio  nTiInComp  nTvInComp  TiTvRatioStandard  nTiDerived  nTvDerived  tiTvDerivedRatio
+TiTvVariantEvaluator  dbsnp    eval     none            all      2565630  1275745       2.01    6956420    3772759               1.84           0           0              0.00
+TiTvVariantEvaluator  dbsnp    eval     none            known    2209800  1070368       2.06    2221957    1083046               2.05           0           0              0.00
+TiTvVariantEvaluator  dbsnp    eval     none            novel     355830   205377       1.73    4734463    2689713               1.76           0           0              0.00
+
+#:GATKTable:24:3:%s:%s:%s:%s:%s:%d:%d:%d:%d:%d:%.2f:%.2f:%.2f:%.2f:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:;
+#:GATKTable:ValidationReport:Assess site accuracy and sensitivity of callset against follow-up validation assay
+ValidationReport  CompRod  EvalRod  JexlExpression  Novelty  nComp     TP       FP  FN       TN  sensitivity  specificity  PPV     FDR   CompMonoEvalNoCall  CompMonoEvalFiltered  CompMonoEvalMono  CompMonoEvalPoly  CompPolyEvalNoCall  CompPolyEvalFiltered  CompPolyEvalMono  CompPolyEvalPoly  CompFiltered  nDifferentAlleleSites
+ValidationReport  dbsnp    eval     none            all      13513872  3879176   0  9634696   0        28.71       100.00  100.00  0.00                   0                     0                 0                 0             9634696                     0                 0           3879176             0                      0
+ValidationReport  dbsnp    eval     none            known     3924503  3879176   0    45327   0        98.85       100.00  100.00  0.00                   0                     0                 0                 0               45327                     0                 0           3879176             0                      0
+ValidationReport  dbsnp    eval     none            novel     9589369        0   0  9589369   0         0.00       100.00     NaN   NaN                   0                     0                 0                 0             9589369                     0                 0                 0             0                      0
+
+#:GATKTable:20:3:%s:%s:%s:%s:%s:%d:%d:%d:%.2f:%s:%d:%.2f:%.1f:%d:%s:%d:%.1f:%d:%s:%d:;
+#:GATKTable:VariantSummary:1000 Genomes Phase I summary of variants table
+VariantSummary  CompRod  EvalRod  JexlExpression  Novelty  nSamples  nProcessedLoci  nSNPs    TiTvRatio  SNPNoveltyRate  nSNPsPerSample  TiTvRatioPerSample  SNPDPPerSample  nIndels  IndelNoveltyRate  nIndelsPerSample  IndelDPPerSample  nSVs  SVNoveltyRate  nSVsPerSample
+VariantSummary  dbsnp    eval     none            all             1      3137454505  3842688       2.01           14.61         3842688                2.01       3805448.0  1012079             41.42           1012079          923745.0  2078          93.02           2078
+VariantSummary  dbsnp    eval     none            known           1      3137454505  3281335       2.06            0.00         3281335                2.06       3263727.0   592860              0.00            592860          578005.0   145           0.00            145
+VariantSummary  dbsnp    eval     none            novel           1      3137454505   561353       1.73          100.00          561353                1.73        541721.0   419219            100.00            419219          345740.0  1933         100.00           1933
+

--- a/data/modules/gatk/ADM1594A12_exome.vcf.varianteval
+++ b/data/modules/gatk/ADM1594A12_exome.vcf.varianteval
@@ -1,0 +1,121 @@
+#:GATKReport.v1.1:9
+#:GATKTable:11:3:%s:%s:%s:%s:%s:%d:%d:%d:%.2f:%d:%.2f:;
+#:GATKTable:CompOverlap:The overlap between eval and comp sites
+CompOverlap  CompRod  EvalRod  JexlExpression  Novelty  nEvalVariants  novelSites  nVariantsAtComp  compRate  nConcordant  concordantRate
+CompOverlap  dbsnp    eval     none            all              32746       17660            15086     46.07        13740           91.08
+CompOverlap  dbsnp    eval     none            known            15086           0            15086    100.00        13740           91.08
+CompOverlap  dbsnp    eval     none            novel            17660       17660                0      0.00            0            0.00
+
+#:GATKTable:30:3:%s:%s:%s:%s:%s:%d:%d:%d:%d:%.8f:%.8f:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%.2e:%.2f:%.2f:%.2e:%.2f:%.2f:;
+#:GATKTable:CountVariants:Counts different classes of variants in the sample
+CountVariants  CompRod  EvalRod  JexlExpression  Novelty  nProcessedLoci  nCalledLoci  nRefLoci  nVariantLoci  variantRate  variantRatePerBp  nSNPs  nMNPs  nInsertions  nDeletions  nComplex  nSymbolic  nMixed  nNoCalls  nHets  nHomRef  nHomVar  nSingletons  nHomDerived  heterozygosity  heterozygosityPerBp  hetHomRatio  indelRate  indelRatePerBp  insertionDeletionRatio
+CountVariants  dbsnp    eval     none            all          3137454505        32746         0         32746   0.00001044    95811.00000000  21688   2768         2862        3693      1604          0     131         0  26304        0     6442        20356            0        8.38e-06            119276.00         4.08   2.60e-06       384539.00                    0.77
+CountVariants  dbsnp    eval     none            known        3137454505        15086         0         15086   0.00000481   207971.00000000  11472    132         1392        1365       725          0       0         0  11705        0     3381         9323            0        3.73e-06            268043.00         3.46   1.11e-06       901049.00                    1.02
+CountVariants  dbsnp    eval     none            novel        3137454505        17660         0         17660   0.00000563   177658.00000000  10216   2636         1470        2328       879          0     131         0  14599        0     3061        11033            0        4.65e-06            214908.00         4.77   1.49e-06       670826.00                    0.63
+
+#:GATKTable:7:60:%s:%s:%s:%s:%s:%d:%.2f:;
+#:GATKTable:IndelLengthHistogram:Indel length histogram
+IndelLengthHistogram  CompRod  EvalRod  JexlExpression  Novelty  Length  Freq
+IndelLengthHistogram  dbsnp    eval     none            all         -10  0.02
+IndelLengthHistogram  dbsnp    eval     none            all          -9  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -8  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -7  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          -6  0.03
+IndelLengthHistogram  dbsnp    eval     none            all          -5  0.02
+IndelLengthHistogram  dbsnp    eval     none            all          -4  0.06
+IndelLengthHistogram  dbsnp    eval     none            all          -3  0.07
+IndelLengthHistogram  dbsnp    eval     none            all          -2  0.11
+IndelLengthHistogram  dbsnp    eval     none            all          -1  0.20
+IndelLengthHistogram  dbsnp    eval     none            all           1  0.19
+IndelLengthHistogram  dbsnp    eval     none            all           2  0.10
+IndelLengthHistogram  dbsnp    eval     none            all           3  0.05
+IndelLengthHistogram  dbsnp    eval     none            all           4  0.05
+IndelLengthHistogram  dbsnp    eval     none            all           5  0.01
+IndelLengthHistogram  dbsnp    eval     none            all           6  0.02
+IndelLengthHistogram  dbsnp    eval     none            all           7  0.00
+IndelLengthHistogram  dbsnp    eval     none            all           8  0.01
+IndelLengthHistogram  dbsnp    eval     none            all           9  0.01
+IndelLengthHistogram  dbsnp    eval     none            all          10  0.01
+IndelLengthHistogram  dbsnp    eval     none            known       -10  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -9  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -8  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -7  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -6  0.02
+IndelLengthHistogram  dbsnp    eval     none            known        -5  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        -4  0.05
+IndelLengthHistogram  dbsnp    eval     none            known        -3  0.05
+IndelLengthHistogram  dbsnp    eval     none            known        -2  0.10
+IndelLengthHistogram  dbsnp    eval     none            known        -1  0.22
+IndelLengthHistogram  dbsnp    eval     none            known         1  0.24
+IndelLengthHistogram  dbsnp    eval     none            known         2  0.10
+IndelLengthHistogram  dbsnp    eval     none            known         3  0.05
+IndelLengthHistogram  dbsnp    eval     none            known         4  0.05
+IndelLengthHistogram  dbsnp    eval     none            known         5  0.01
+IndelLengthHistogram  dbsnp    eval     none            known         6  0.02
+IndelLengthHistogram  dbsnp    eval     none            known         7  0.00
+IndelLengthHistogram  dbsnp    eval     none            known         8  0.01
+IndelLengthHistogram  dbsnp    eval     none            known         9  0.01
+IndelLengthHistogram  dbsnp    eval     none            known        10  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel       -10  0.02
+IndelLengthHistogram  dbsnp    eval     none            novel        -9  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        -8  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        -7  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        -6  0.04
+IndelLengthHistogram  dbsnp    eval     none            novel        -5  0.03
+IndelLengthHistogram  dbsnp    eval     none            novel        -4  0.08
+IndelLengthHistogram  dbsnp    eval     none            novel        -3  0.09
+IndelLengthHistogram  dbsnp    eval     none            novel        -2  0.11
+IndelLengthHistogram  dbsnp    eval     none            novel        -1  0.18
+IndelLengthHistogram  dbsnp    eval     none            novel         1  0.15
+IndelLengthHistogram  dbsnp    eval     none            novel         2  0.10
+IndelLengthHistogram  dbsnp    eval     none            novel         3  0.04
+IndelLengthHistogram  dbsnp    eval     none            novel         4  0.05
+IndelLengthHistogram  dbsnp    eval     none            novel         5  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel         6  0.03
+IndelLengthHistogram  dbsnp    eval     none            novel         7  0.00
+IndelLengthHistogram  dbsnp    eval     none            novel         8  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel         9  0.01
+IndelLengthHistogram  dbsnp    eval     none            novel        10  0.01
+
+#:GATKTable:30:3:%s:%s:%s:%s:%s:%d:%d:%d:%d:%d:%s:%s:%s:%s:%s:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:;
+#:GATKTable:IndelSummary:Evaluation summary for indels
+IndelSummary  CompRod  EvalRod  JexlExpression  Novelty  n_SNPs  n_singleton_SNPs  n_indels  n_singleton_indels  n_indels_matching_gold_standard  gold_standard_matching_rate  n_multiallelic_indel_sites  percent_of_sites_with_more_than_2_alleles  SNP_to_indel_ratio  SNP_to_indel_ratio_for_singletons  n_novel_indels  indel_novelty_rate  n_insertions  n_deletions  insertion_to_deletion_ratio  n_large_deletions  n_large_insertions  insertion_to_deletion_ratio_for_large_indels  n_coding_indels_frameshifting  n_coding_indels_in_frame  frameshift_rate_for_coding_indels  SNP_het_to_hom_ratio  indel_het_to_hom_ratio  ratio_of_1_and_2_to_3_bp_insertions  ratio_of_1_and_2_to_3_bp_deletions
+IndelSummary  dbsnp    eval     none            all       21701             18300      8983                6641                             2434                        27.10                         824                                      10.10                2.42                               2.76            4953               55.14          4040         4943                         0.82                820                 393                                          0.48                              0                         0                                 NA                  5.40                    2.48                                 6.05                                4.91
+IndelSummary  dbsnp    eval     none            known     11482              9234      4030                2930                             1726                        42.83                         548                                      15.74                2.85                               3.15               0                0.00          2077         1953                         1.06                174                 158                                          0.91                              0                         0                                 NA                  4.13                    2.17                                 6.28                                7.90
+IndelSummary  dbsnp    eval     none            novel     10219              9066      4953                3711                              708                        14.29                         276                                       5.90                2.06                               2.44            4953              100.00          1963         2990                         0.66                646                 235                                          0.36                              0                         0                                 NA                  7.88                    2.77                                 5.79                                3.61
+
+#:GATKTable:13:3:%s:%s:%s:%s:%s:%.2f:%d:%d:%d:%d:%s:%.2f:%.2f:;
+#:GATKTable:MetricsCollection:Metrics Collection
+MetricsCollection  CompRod  EvalRod  JexlExpression  Novelty  concordantRate  nSNPs  nSNPloci  nIndels  nIndelLoci  indelRatio  indelRatioLociBased  tiTvRatio
+MetricsCollection  dbsnp    eval     none            all               91.08  21701     21688     8983        8159        0.82                 0.77       1.98
+MetricsCollection  dbsnp    eval     none            known             91.08  11482     11472     4030        3482        1.06                 1.02       2.06
+MetricsCollection  dbsnp    eval     none            novel              0.00  10219     10216     4953        4677        0.66                 0.63       1.90
+
+#:GATKTable:20:3:%s:%s:%s:%s:%s:%d:%d:%d:%.5f:%.3f:%d:%d:%.5f:%.3f:%d:%d:%.2f:%d:%d:%s:;
+#:GATKTable:MultiallelicSummary:Evaluation summary for multi-allelic variants
+MultiallelicSummary  CompRod  EvalRod  JexlExpression  Novelty  nProcessedLoci  nSNPs  nMultiSNPs  processedMultiSnpRatio  variantMultiSnpRatio  nIndels  nMultiIndels  processedMultiIndelRatio  variantMultiIndelRatio  nTi  nTv  TiTvRatio  knownSNPsPartial  knownSNPsComplete  SNPNoveltyRate
+MultiallelicSummary  dbsnp    eval     none            all          3137454505  21688          13                 0.00000                 0.001     8159           824                   0.00000                   0.101   10   16       0.63                10                  0           23.08
+MultiallelicSummary  dbsnp    eval     none            known        3137454505  11472          10                 0.00000                 0.001     3482           548                   0.00000                   0.157    7   13       0.54                10                  0            0.00
+MultiallelicSummary  dbsnp    eval     none            novel        3137454505  10216           3                 0.00000                 0.000     4677           276                   0.00000                   0.059    3    3       1.00                 0                  0          100.00
+
+#:GATKTable:14:3:%s:%s:%s:%s:%s:%d:%d:%.2f:%d:%d:%.2f:%d:%d:%.2f:;
+#:GATKTable:TiTvVariantEvaluator:Ti/Tv Variant Evaluator
+TiTvVariantEvaluator  CompRod  EvalRod  JexlExpression  Novelty  nTi    nTv   tiTvRatio  nTiInComp  nTvInComp  TiTvRatioStandard  nTiDerived  nTvDerived  tiTvDerivedRatio
+TiTvVariantEvaluator  dbsnp    eval     none            all      14411  7264       1.98    6965450    3796020               1.83           0           0              0.00
+TiTvVariantEvaluator  dbsnp    eval     none            known     7717  3745       2.06       7865       3870               2.03           0           0              0.00
+TiTvVariantEvaluator  dbsnp    eval     none            novel     6694  3519       1.90    6957585    3792150               1.83           0           0              0.00
+
+#:GATKTable:24:3:%s:%s:%s:%s:%s:%d:%d:%d:%d:%d:%.2f:%.2f:%.2f:%.2f:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:;
+#:GATKTable:ValidationReport:Assess site accuracy and sensitivity of callset against follow-up validation assay
+ValidationReport  CompRod  EvalRod  JexlExpression  Novelty  nComp     TP     FP  FN        TN  sensitivity  specificity  PPV     FDR   CompMonoEvalNoCall  CompMonoEvalFiltered  CompMonoEvalMono  CompMonoEvalPoly  CompPolyEvalNoCall  CompPolyEvalFiltered  CompPolyEvalMono  CompPolyEvalPoly  CompFiltered  nDifferentAlleleSites
+ValidationReport  dbsnp    eval     none            all      13941821  15086   0  13926735   0         0.11       100.00  100.00  0.00                   0                     0                 0                 0            13926735                     0                 0             15086             0                      0
+ValidationReport  dbsnp    eval     none            known       15489  15086   0       403   0        97.40       100.00  100.00  0.00                   0                     0                 0                 0                 403                     0                 0             15086             0                      0
+ValidationReport  dbsnp    eval     none            novel    13926332      0   0  13926332   0         0.00       100.00     NaN   NaN                   0                     0                 0                 0            13926332                     0                 0                 0             0                      0
+
+#:GATKTable:20:3:%s:%s:%s:%s:%s:%d:%d:%d:%.2f:%s:%d:%.2f:%.1f:%d:%s:%d:%.1f:%d:%s:%d:;
+#:GATKTable:VariantSummary:1000 Genomes Phase I summary of variants table
+VariantSummary  CompRod  EvalRod  JexlExpression  Novelty  nSamples  nProcessedLoci  nSNPs  TiTvRatio  SNPNoveltyRate  nSNPsPerSample  TiTvRatioPerSample  SNPDPPerSample  nIndels  IndelNoveltyRate  nIndelsPerSample  IndelDPPerSample  nSVs  SVNoveltyRate  nSVsPerSample
+VariantSummary  dbsnp    eval     none            all             1      3137454505  21688       1.98           47.10           21688                1.98         21009.0     8056             56.85              8056            6997.0   103          94.17            103
+VariantSummary  dbsnp    eval     none            known           1      3137454505  11472       2.06            0.00           11472                2.06         11202.0     3476              0.00              3476            3309.0     6           0.00              6
+VariantSummary  dbsnp    eval     none            novel           1      3137454505  10216       1.90          100.00           10216                1.90          9807.0     4580            100.00              4580            3688.0    97         100.00             97
+


### PR DESCRIPTION
The two files are run on the whole VCF vs. the exome in some form

I can ask @henrikstranneheim if none of us quite understand it 😉 