### PR TITLE
Update plotCoverage example

### DIFF
--- a/data/modules/deeptools/plotCoverage_outRawCounts.txt
+++ b/data/modules/deeptools/plotCoverage_outRawCounts.txt
@@ -1,3 +1,4 @@
+#plotCoverage --outRawCounts
 #'chr'	'start'	'end'	'bwameth_se.pbat.bam'	'bismark_se.pbat.bam'
 KI270589.1	43386	43387	4.0	0.0
 13	16229463	16229464	1.0	0.0


### PR DESCRIPTION
This updates the example for `plotCoverage --outRawCounts` to use the "more likely to be unique" header from version 2.6.