### PR TITLE
Added distinguishable content header to BISCUIT log files

### DIFF
--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_CpGRetentionByReadPos.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_CpGRetentionByReadPos.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Retention by Read Position Table
+ReadInPair	Position	Conversion/Retention	Count
 1	0	C	20193
 1	0	R	13887
 1	1	C	43665

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_CpGRetentionDist.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_CpGRetentionDist.txt
@@ -1,3 +1,5 @@
+BISCUITqc Retention Distribution Table
+RetentionFraction	Count
   0	548005
   1	148
   2	171

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_CpHRetentionByReadPos.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_CpHRetentionByReadPos.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpH Retention by Read Position Table
+ReadInPair	Position	Conversion/Retention	Count
 1	0	C	395274
 1	0	R	109057
 1	1	C	868724

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_all_cv_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_all_cv_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc Uniformity Table
 sample	mu	sigma	cv
 mouse_ESCs_E14_GSM1370557_all	0.478375	8.313	17.3776
 mouse_ESCs_E14_GSM1370557_all_topgc	1.1938	15.138	12.6805

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_q40_botgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_q40_botgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (low GC, Q40)
+depth	count
 0	568579
 1	30803
 2	14899

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_q40_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_q40_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (Q40)
+depth	count
 0	16368516
 1	1921750
 2	1381998

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_q40_topgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_q40_topgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (high GC, Q40)
+depth	count
 0	3714567
 1	569500
 2	483681

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_cpg_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (All)
+depth	count
 0	14715924
 1	2560843
 2	1789142

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_q40_botgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_q40_botgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (low GC, Q40)
+depth	count
 0	243583456
 1	12019943
 2	5671775

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_q40_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_q40_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (Q40)
+depth	count
 0	2221768738
 1	210987163
 2	134748857

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_q40_topgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_q40_topgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (high GC, Q40)
+depth	count
 0	176601449
 1	27020936
 2	20832950

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_covdist_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (All)
+depth	count
 0	2060348297
 1	280294114
 2	172361184

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_cpg_cv_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_cpg_cv_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc CpG Uniformity Table
 sample	mu	sigma	cv
 mouse_ESCs_E14_GSM1370557_cpg	0.88712	27.6214	31.136
 mouse_ESCs_E14_GSM1370557_cpg_topgc	1.7906	31.552	17.6209

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_cpg_dist_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_cpg_dist_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc CpG Distribution Table
 Territory	All	UniqCov	AllCov
 TotalCpGs	21867837	5499321	7151913
 ExonicCpGs	2151165	877574	973573

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_dup_report.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_dup_report.txt
@@ -1,3 +1,4 @@
+BISCUITqc Read Duplication Table
 #bases covered by all reads: 670523477
 #bases covered by duplicate reads: 170981248
 #high-GC bases covered by all reads: 111837137

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_freqOfTotalRetentionPerRead.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_freqOfTotalRetentionPerRead.txt
@@ -1,3 +1,4 @@
+BISCUITqc Frequency of Total Retention per Read Table
 CTXT	numRET	Cnt
 CA	0	13266485
 CA	1	1963068

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_isize_score_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_isize_score_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Insert Size Table
+InsertSize/Score	Value	Fraction
 I	2	0.000751564
 I	3	0.00102509
 I	4	0.000908154

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_isize_score_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_isize_score_table.txt
@@ -1,4 +1,4 @@
-BISCUITqc Insert Size Table
+BISCUITqc Insert Size, Score Table
 InsertSize/Score	Value	Fraction
 I	2	0.000751564
 I	3	0.00102509

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_mapq_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_mapq_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Mapping Quality Table
+MapQ	Count
 unmapped	7262577
 0	18473997
 1	168691

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_strand_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_strand_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc Strand Table
 strand	++	6938226
 strand	-+	7893166
 strand	+-	6923678

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_strand_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_strand_table.txt
@@ -1,5 +1,9 @@
 BISCUITqc Strand Table
-strand	++	6938226
-strand	-+	7893166
-strand	+-	6923678
-strand	--	6297207
+strand	2-+	4978289
+strand	2+-	4239357
+strand	2--	2440204
+strand	1++	4308570
+strand	1+-	2684321
+strand	1-+	2914877
+strand	1--	3857003
+strand	2++	2629656

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalBaseConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalBaseConversionRate.txt
@@ -1,3 +1,3 @@
-BISCUITqc Conversion Rate by Base Averaging Table
+BISCUITqc Conversion Rate by Base Average Table
 CA	CC	CG	CT
 0.0263828	0.0229048	0.347166	0.0160132

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalBaseConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalBaseConversionRate.txt
@@ -1,2 +1,3 @@
+BISCUITqc Conversion Rate by Base Averaging Table
 CA	CC	CG	CT
 0.0263828	0.0229048	0.347166	0.0160132

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalReadConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalReadConversionRate.txt
@@ -1,2 +1,3 @@
+BISCUITqc Conversion Rate by Read Averaging Table
 CpA	CpC	CpG	CpT
 0.0492347	0.0590908	0.434188	0.0337826

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalReadConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370557_totalReadConversionRate.txt
@@ -1,3 +1,3 @@
-BISCUITqc Conversion Rate by Read Averaging Table
+BISCUITqc Conversion Rate by Read Average Table
 CpA	CpC	CpG	CpT
 0.0492347	0.0590908	0.434188	0.0337826

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_CpGRetentionByReadPos.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_CpGRetentionByReadPos.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Retention by Read Position Table
+ReadInPair	Position	Conversion/Retention	Count
 1	0	C	15950
 1	0	R	14472
 1	1	C	33419

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_CpGRetentionDist.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_CpGRetentionDist.txt
@@ -1,3 +1,5 @@
+BISCUITqc Retention Distribution Table
+RetentionFraction	Count
   0	373689
   1	213
   2	175

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_CpHRetentionByReadPos.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_CpHRetentionByReadPos.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpH Retention by Read Position Table
+ReadInPair	Position	Conversion/Retention	Count
 1	0	C	349701
 1	0	R	94759
 1	1	C	767557

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_all_cv_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_all_cv_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc Uniformity Table
 sample	mu	sigma	cv
 mouse_ESCs_E14_GSM1370558_all	0.413415	8.54128	20.6603
 mouse_ESCs_E14_GSM1370558_all_topgc	1.13742	18.3824	16.1615

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_q40_botgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_q40_botgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (low GC, Q40)
+depth	count
 0	575574
 1	30400
 2	12078

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_q40_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_q40_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (Q40)
+depth	count
 0	16148739
 1	2291501
 2	1453998

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_q40_topgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_q40_topgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (high GC, Q40)
+depth	count
 0	3461418
 1	738795
 2	562591

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_cpg_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (All)
+depth	count
 0	14723710
 1	2883087
 2	1813895

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_q40_botgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_q40_botgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (low GC, Q40)
+depth	count
 0	246410907
 1	11814924
 2	4496497

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_q40_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_q40_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (Q40)
+depth	count
 0	2228647441
 1	238522627
 2	132553847

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_q40_topgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_q40_topgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (high GC, Q40)
+depth	count
 0	167172658
 1	34386762
 2	24091306

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_covdist_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (All)
+depth	count
 0	2089140846
 1	301765950
 2	166150438

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_cpg_cv_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_cpg_cv_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc CpG Uniformity Table
 sample	mu	sigma	cv
 mouse_ESCs_E14_GSM1370558_cpg	0.812465	29.2506	36.0023
 mouse_ESCs_E14_GSM1370558_cpg_topgc	1.71095	38.8573	22.711

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_cpg_dist_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_cpg_dist_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc CpG Distribution Table
 Territory	All	UniqCov	AllCov
 TotalCpGs	21867837	5719098	7144127
 ExonicCpGs	2151165	999051	1089388

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_dup_report.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_dup_report.txt
@@ -1,3 +1,4 @@
+BISCUITqc Read Duplication Table
 #bases covered by all reads: 641730928
 #bases covered by duplicate reads: 108112627
 #high-GC bases covered by all reads: 119214339

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_freqOfTotalRetentionPerRead.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_freqOfTotalRetentionPerRead.txt
@@ -1,3 +1,4 @@
+BISCUITqc Frequency of Total Retention per Read Table
 CTXT	numRET	Cnt
 CA	0	11522703
 CA	1	1817900

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_isize_score_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_isize_score_table.txt
@@ -1,4 +1,4 @@
-BISCUITqc Insert Size Table
+BISCUITqc Insert Size, Score Table
 InsertSize/Score	Value	Fraction
 I	2	0.000783086
 I	3	0.00103645

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_isize_score_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_isize_score_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Insert Size Table
+InsertSize/Score	Value	Fraction
 I	2	0.000783086
 I	3	0.00103645
 I	4	0.000909472

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_mapq_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_mapq_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Mapping Quality Table
+MapQ	Count
 unmapped	7271756
 0	11657199
 1	140688

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_strand_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_strand_table.txt
@@ -1,5 +1,9 @@
 BISCUITqc Strand Table
-strand	++	6016590
-strand	+-	6192134
-strand	-+	6728193
-strand	--	5677579
+strand	2+-	3872237
+strand	2-+	4253090
+strand	2--	2144654
+strand	1++	3753624
+strand	1+-	2319897
+strand	1-+	2475103
+strand	1--	3532925
+strand	2++	2262966

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_strand_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_strand_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc Strand Table
 strand	++	6016590
 strand	+-	6192134
 strand	-+	6728193

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalBaseConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalBaseConversionRate.txt
@@ -1,3 +1,3 @@
-BISCUITqc Conversion Rate by Base Averaging Table
+BISCUITqc Conversion Rate by Base Average Table
 CA	CC	CG	CT
 0.0277436	0.0244615	0.470713	0.0157643

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalBaseConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalBaseConversionRate.txt
@@ -1,2 +1,3 @@
+BISCUITqc Conversion Rate by Base Averaging Table
 CA	CC	CG	CT
 0.0277436	0.0244615	0.470713	0.0157643

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalReadConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalReadConversionRate.txt
@@ -1,2 +1,3 @@
+BISCUITqc Conversion Rate by Read Averaging Table
 CpA	CpC	CpG	CpT
 0.0510329	0.0595524	0.589749	0.0344048

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalReadConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370558_totalReadConversionRate.txt
@@ -1,3 +1,3 @@
-BISCUITqc Conversion Rate by Read Averaging Table
+BISCUITqc Conversion Rate by Read Average Table
 CpA	CpC	CpG	CpT
 0.0510329	0.0595524	0.589749	0.0344048

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_CpGRetentionByReadPos.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_CpGRetentionByReadPos.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Retention by Read Position Table
+ReadInPair	Position	Conversion/Retention	Count
 1	0	C	14021
 1	0	R	12706
 1	1	C	30619

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_CpGRetentionDist.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_CpGRetentionDist.txt
@@ -1,3 +1,5 @@
+BISCUITqc Retention Distribution Table
+RetentionFraction	Count
   0	260037
   1	138
   2	163

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_CpHRetentionByReadPos.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_CpHRetentionByReadPos.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpH Retention by Read Position Table
+ReadInPair	Position	Conversion/Retention	Count
 1	0	C	288409
 1	0	R	91868
 1	1	C	633615

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_all_cv_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_all_cv_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc Uniformity Table
 sample	mu	sigma	cv
 mouse_ESCs_E14_GSM1370559_all	0.342191	11.888	34.7408
 mouse_ESCs_E14_GSM1370559_all_topgc	0.913676	32.4183	35.4812

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_q40_botgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_q40_botgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (low GC, Q40)
+depth	count
 0	581306
 1	27006
 2	10661

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_q40_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_q40_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (Q40)
+depth	count
 0	17127460
 1	1961343
 2	1278044

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_q40_topgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_q40_topgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (high GC, Q40)
+depth	count
 0	3902519
 1	639495
 2	504674

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_cpg_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc CpG Depth Distribution (All)
+depth	count
 0	15772241
 1	2545196
 2	1628489

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_q40_botgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_q40_botgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (low GC, Q40)
+depth	count
 0	248452196
 1	10547119
 2	4034186

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_q40_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_q40_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (Q40)
+depth	count
 0	2307376701
 1	207941611
 2	115220116

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_q40_topgc_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_q40_topgc_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (high GC, Q40)
+depth	count
 0	185649304
 1	29857561
 2	20769146

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_covdist_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Depth Distribution (All)
+depth	count
 0	2172669323
 1	270411978
 2	148123030

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_cpg_cv_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_cpg_cv_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc CpG Uniformity Table
 sample	mu	sigma	cv
 mouse_ESCs_E14_GSM1370559_cpg	0.724652	39.1962	54.0897
 mouse_ESCs_E14_GSM1370559_cpg_topgc	1.54298	69.2464	44.8785

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_cpg_dist_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_cpg_dist_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc CpG Distribution Table
 Territory	All	UniqCov	AllCov
 TotalCpGs	21867837	4740377	6095596
 ExonicCpGs	2151165	799961	882698

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_dup_report.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_dup_report.txt
@@ -1,3 +1,4 @@
+BISCUITqc Read Duplication Table
 #bases covered by all reads: 558202451
 #bases covered by duplicate reads: 93485165
 #high-GC bases covered by all reads: 100211662

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_freqOfTotalRetentionPerRead.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_freqOfTotalRetentionPerRead.txt
@@ -1,3 +1,4 @@
+BISCUITqc Frequency of Total Retention per Read Table
 CTXT	numRET	Cnt
 CA	0	10031055
 CA	1	2011526

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_isize_score_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_isize_score_table.txt
@@ -1,4 +1,4 @@
-BISCUITqc Insert Size Table
+BISCUITqc Insert Size, Score Table
 InsertSize/Score	Value	Fraction
 I	2	0.000733913
 I	3	0.00104912

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_isize_score_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_isize_score_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Insert Size Table
+InsertSize/Score	Value	Fraction
 I	2	0.000733913
 I	3	0.00104912
 I	4	0.000914032

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_mapq_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_mapq_table.txt
@@ -1,3 +1,5 @@
+BISCUITqc Mapping Quality Table
+MapQ	Count
 unmapped	12264216
 0	13113957
 1	159295

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_strand_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_strand_table.txt
@@ -1,3 +1,4 @@
+BISCUITqc Strand Table
 strand	++	5893079
 strand	+-	5847550
 strand	-+	6540150

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_strand_table.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_strand_table.txt
@@ -1,5 +1,9 @@
 BISCUITqc Strand Table
-strand	++	5893079
-strand	+-	5847550
-strand	-+	6540150
-strand	--	5430571
+strand	2+-	3506225
+strand	2-+	4000253
+strand	2--	2238521
+strand	1++	3522267
+strand	1-+	2539897
+strand	1+-	2341325
+strand	1--	3192050
+strand	2++	2370812

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalBaseConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalBaseConversionRate.txt
@@ -1,2 +1,3 @@
+BISCUITqc Conversion Rate by Base Averaging Table
 CA	CC	CG	CT
 0.0370512	0.0422894	0.47003	0.0234694

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalBaseConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalBaseConversionRate.txt
@@ -1,3 +1,3 @@
-BISCUITqc Conversion Rate by Base Averaging Table
+BISCUITqc Conversion Rate by Base Average Table
 CA	CC	CG	CT
 0.0370512	0.0422894	0.47003	0.0234694

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalReadConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalReadConversionRate.txt
@@ -1,2 +1,3 @@
+BISCUITqc Conversion Rate by Read Averaging Table
 CpA	CpC	CpG	CpT
 0.0739631	0.106655	0.609849	0.0530022

--- a/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalReadConversionRate.txt
+++ b/data/modules/biscuit/test_data/mouse_ESCs_E14_GSM1370559_totalReadConversionRate.txt
@@ -1,3 +1,3 @@
-BISCUITqc Conversion Rate by Read Averaging Table
+BISCUITqc Conversion Rate by Read Average Table
 CpA	CpC	CpG	CpT
 0.0739631	0.106655	0.609849	0.0530022


### PR DESCRIPTION
Sorry for requesting more merge. I added a few distinguishable content header so that the files can be uniquely identified using `content` specified in search pattern.

Thank you