### PR TITLE
Add Testdata for DeDup v0.12.4, mtnucratio v0.5

### DIFF
--- a/data/modules/dedup/v0.12.4/output.filtered.sorted.dedup.json
+++ b/data/modules/dedup/v0.12.4/output.filtered.sorted.dedup.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "tool_name": "DeDup",
+    "version": "0.12.4",
+    "sample_name": "JK2785_TGGCCGATCAACGA_L008_R1_001.sorted.bam.filtered.sorted.bam"
+  },
+  "metrics": {
+    "total_reads": 9865,
+    "merged_removed": 0,
+    "forward_removed": 0,
+    "total_removed": 0,
+    "reverse_removed": 0,
+    "dup_rate": "0",
+    "clusterfactor": "1"
+  }
+}

--- a/data/modules/mtnucratio/filebam.mtnuc.json
+++ b/data/modules/mtnucratio/filebam.mtnuc.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "tool_name": "mtnuccalculator",
+    "version": "0.5",
+    "sample_name": "testme.sorted.bam.filtered.bam"
+  },
+  "metrics": {
+    "mt_cov_avg": 320.42,
+    "nuc_cov_avg": 5.847763864042934,
+    "mt_nuc_ratio": 54.7935941754,
+    "mtreads": 65588,
+    "nucreads": 1197
+  }
+}


### PR DESCRIPTION
Hi Phil!

this adds appropriate (JSON format, both cases) testdata for:

- DeDup v0.12.4 (which I hacked to have JSON output now)
- mtnucratio v0.5 (which I added that as well) 

Let me know if you're missing something in here - will start writing the modules for MultiQC these days and hopefully be done in the next couple of days too :-) 
