### PR TITLE
Add README for DeDup

### DIFF
--- a/data/modules/dedup/v0.11.3/README.md
+++ b/data/modules/dedup/v0.11.3/README.md
@@ -1,0 +1,3 @@
+# Note to users of DeDup < 0.12.4
+
+DeDup versions prior to 0.12.4 used a different output format for metrics. This format is solely supported by MultiQC Versions 1.7 and lower. Newer DeDup versions such as 0.12.4 support JSON output of metrics, supported in MultiQC v1.8+. If you need to rely on the old version, please use MultiQC V1.7 or lower to read older data.


### PR DESCRIPTION
Add Readme as discussed [here](https://github.com/ewels/MultiQC/pull/929/) to notify users of older DeDup versions that this will only be supported by MultiQC v1.7 and lower from now on! 