### PR TITLE
add odgi v0.6.0 test files

### DIFF
--- a/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.cons@10000__y_0_1000000.gfa.og.stats.yaml
+++ b/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.cons@10000__y_0_1000000.gfa.og.stats.yaml
@@ -1,0 +1,71 @@
+---
+length: 13590092
+nodes: 10467
+edges: 13856
+paths: 3498
+num_weakly_connected_components: 10
+weakly_connected_components: 
+  - component:
+      id: 0
+      nodes: 251
+      is_acyclic: 'no'
+  - component:
+      id: 1
+      nodes: 401
+      is_acyclic: 'no'
+  - component:
+      id: 2
+      nodes: 146
+      is_acyclic: 'no'
+  - component:
+      id: 3
+      nodes: 180
+      is_acyclic: 'no'
+  - component:
+      id: 4
+      nodes: 117
+      is_acyclic: 'no'
+  - component:
+      id: 5
+      nodes: 146
+      is_acyclic: 'no'
+  - component:
+      id: 6
+      nodes: 2086
+      is_acyclic: 'no'
+  - component:
+      id: 7
+      nodes: 6617
+      is_acyclic: 'no'
+  - component:
+      id: 8
+      nodes: 237
+      is_acyclic: 'no'
+  - component:
+      id: 9
+      nodes: 286
+      is_acyclic: 'no'
+num_nodes_self_loops:
+  total: 0
+  unique: 0
+A: 4179762
+C: 2610340
+G: 2618541
+N: 10387
+T: 4171062
+mean_links_length:
+  - length:
+      path: all_paths
+      in_node_space: 2.97432
+      in_nucleotide_space: 34.1461
+      num_links_considered: 10630
+      num_gap_links_not_penalized: 3936
+sum_of_path_node_distances:
+  - distance:
+      path: all_paths
+      in_node_space: 7.50772
+      in_nucleotide_space: 1.95647
+      nodes: 14128
+      nucleotides: 13596661
+      num_penalties: 103
+      num_penalties_different_orientation: 2

--- a/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.cons@1000__y_0_1000000.gfa.og.stats.yaml
+++ b/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.cons@1000__y_0_1000000.gfa.og.stats.yaml
@@ -1,0 +1,71 @@
+---
+length: 13888752
+nodes: 10657
+edges: 14158
+paths: 3588
+num_weakly_connected_components: 10
+weakly_connected_components: 
+  - component:
+      id: 0
+      nodes: 259
+      is_acyclic: 'no'
+  - component:
+      id: 1
+      nodes: 414
+      is_acyclic: 'no'
+  - component:
+      id: 2
+      nodes: 154
+      is_acyclic: 'no'
+  - component:
+      id: 3
+      nodes: 191
+      is_acyclic: 'no'
+  - component:
+      id: 4
+      nodes: 120
+      is_acyclic: 'no'
+  - component:
+      id: 5
+      nodes: 150
+      is_acyclic: 'no'
+  - component:
+      id: 6
+      nodes: 2192
+      is_acyclic: 'no'
+  - component:
+      id: 7
+      nodes: 6635
+      is_acyclic: 'no'
+  - component:
+      id: 8
+      nodes: 243
+      is_acyclic: 'no'
+  - component:
+      id: 9
+      nodes: 299
+      is_acyclic: 'no'
+num_nodes_self_loops:
+  total: 0
+  unique: 0
+A: 4275263
+C: 2666239
+G: 2673380
+N: 10387
+T: 4263483
+mean_links_length:
+  - length:
+      path: all_paths
+      in_node_space: 2.94728
+      in_nucleotide_space: 34.7448
+      num_links_considered: 10735
+      num_gap_links_not_penalized: 4007
+sum_of_path_node_distances:
+  - distance:
+      path: all_paths
+      in_node_space: 8.12428
+      in_nucleotide_space: 2.7928
+      nodes: 14323
+      nucleotides: 13893886
+      num_penalties: 133
+      num_penalties_different_orientation: 2

--- a/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.cons@100__y_0_1000000.gfa.og.stats.yaml
+++ b/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.cons@100__y_0_1000000.gfa.og.stats.yaml
@@ -1,0 +1,71 @@
+---
+length: 13893023
+nodes: 11084
+edges: 14785
+paths: 3698
+num_weakly_connected_components: 10
+weakly_connected_components: 
+  - component:
+      id: 0
+      nodes: 270
+      is_acyclic: 'no'
+  - component:
+      id: 1
+      nodes: 459
+      is_acyclic: 'no'
+  - component:
+      id: 2
+      nodes: 177
+      is_acyclic: 'no'
+  - component:
+      id: 3
+      nodes: 216
+      is_acyclic: 'no'
+  - component:
+      id: 4
+      nodes: 126
+      is_acyclic: 'no'
+  - component:
+      id: 5
+      nodes: 161
+      is_acyclic: 'no'
+  - component:
+      id: 6
+      nodes: 2364
+      is_acyclic: 'no'
+  - component:
+      id: 7
+      nodes: 6654
+      is_acyclic: 'no'
+  - component:
+      id: 8
+      nodes: 344
+      is_acyclic: 'no'
+  - component:
+      id: 9
+      nodes: 313
+      is_acyclic: 'no'
+num_nodes_self_loops:
+  total: 0
+  unique: 0
+A: 4277187
+C: 2666697
+G: 2673556
+N: 10404
+T: 4265179
+mean_links_length:
+  - length:
+      path: all_paths
+      in_node_space: 2.87232
+      in_nucleotide_space: 51.6349
+      num_links_considered: 11114
+      num_gap_links_not_penalized: 4296
+sum_of_path_node_distances:
+  - distance:
+      path: all_paths
+      in_node_space: 8.0561
+      in_nucleotide_space: 2.83992
+      nodes: 14812
+      nucleotides: 13898437
+      num_penalties: 225
+      num_penalties_different_orientation: 2

--- a/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.smooth.og.stats.yaml
+++ b/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.da2dc96.smooth.og.stats.yaml
@@ -1,0 +1,71 @@
+---
+length: 14612171
+nodes: 663169
+edges: 904082
+paths: 3349
+num_weakly_connected_components: 10
+weakly_connected_components: 
+  - component:
+      id: 0
+      nodes: 38807
+      is_acyclic: 'no'
+  - component:
+      id: 1
+      nodes: 76209
+      is_acyclic: 'no'
+  - component:
+      id: 2
+      nodes: 20632
+      is_acyclic: 'no'
+  - component:
+      id: 3
+      nodes: 28130
+      is_acyclic: 'no'
+  - component:
+      id: 4
+      nodes: 18397
+      is_acyclic: 'no'
+  - component:
+      id: 5
+      nodes: 28236
+      is_acyclic: 'no'
+  - component:
+      id: 6
+      nodes: 279469
+      is_acyclic: 'no'
+  - component:
+      id: 7
+      nodes: 76259
+      is_acyclic: 'no'
+  - component:
+      id: 8
+      nodes: 40755
+      is_acyclic: 'no'
+  - component:
+      id: 9
+      nodes: 56275
+      is_acyclic: 'no'
+num_nodes_self_loops:
+  total: 0
+  unique: 0
+A: 4497004
+C: 2809458
+G: 2814746
+N: 10430
+T: 4480533
+mean_links_length:
+  - length:
+      path: all_paths
+      in_node_space: 10.2459
+      in_nucleotide_space: 219.92
+      num_links_considered: 3358826
+      num_gap_links_not_penalized: 2759658
+sum_of_path_node_distances:
+  - distance:
+      path: all_paths
+      in_node_space: 31.9623
+      in_nucleotide_space: 23.9438
+      nodes: 3362175
+      nucleotides: 96868414
+      num_penalties: 516566
+      num_penalties_different_orientation: 49

--- a/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.seqwish.og.stats.yaml
+++ b/data/modules/odgi/v0.6.0/cerevisiae.pan.fa.6ab2ce3.c28ecf8.seqwish.og.stats.yaml
@@ -1,0 +1,71 @@
+---
+length: 15039721
+nodes: 503709
+edges: 681095
+paths: 112
+num_weakly_connected_components: 10
+weakly_connected_components: 
+  - component:
+      id: 0
+      nodes: 217177
+      is_acyclic: 'no'
+  - component:
+      id: 1
+      nodes: 32332
+      is_acyclic: 'no'
+  - component:
+      id: 2
+      nodes: 15689
+      is_acyclic: 'no'
+  - component:
+      id: 3
+      nodes: 61201
+      is_acyclic: 'no'
+  - component:
+      id: 4
+      nodes: 22958
+      is_acyclic: 'no'
+  - component:
+      id: 5
+      nodes: 13644
+      is_acyclic: 'no'
+  - component:
+      id: 6
+      nodes: 20927
+      is_acyclic: 'no'
+  - component:
+      id: 7
+      nodes: 42075
+      is_acyclic: 'no'
+  - component:
+      id: 8
+      nodes: 32049
+      is_acyclic: 'no'
+  - component:
+      id: 9
+      nodes: 45657
+      is_acyclic: 'no'
+num_nodes_self_loops:
+  total: 755
+  unique: 755
+A: 4635834
+C: 2894551
+G: 2894525
+N: 1
+T: 4614810
+mean_links_length:
+  - length:
+      path: all_paths
+      in_node_space: 70498.4
+      in_nucleotide_space: 2.09372e+06
+      num_links_considered: 2437905
+      num_gap_links_not_penalized: 1506708
+sum_of_path_node_distances:
+  - distance:
+      path: all_paths
+      in_node_space: 144888
+      in_nucleotide_space: 125426
+      nodes: 2438017
+      nucleotides: 83530630
+      num_penalties: 400040
+      num_penalties_different_orientation: 25954


### PR DESCRIPTION
This brings in new test files for the updated `odgi` module which is tracked at https://github.com/ewels/MultiQC/pull/1340. 
After this is merged, I will update the PR accordingly, so all test can run through.