### PR TITLE
adding bbsplit refstats file, credit to Bruce Moran

### DIFF
--- a/data/modules/bbmap/sample1/sample1.refstats.txt
+++ b/data/modules/bbmap/sample1/sample1.refstats.txt
@@ -1,0 +1,3 @@
+#name   %unambiguousReads       unambiguousMB   %ambiguousReads ambiguousMB     unambiguousReads        ambiguousReads
+hg38    83.16030        5598.96128      1.11830 51.55901        87337366        1174470
+mm38    15.56726        1051.54145      1.11830 51.55901        16349186        1174470


### PR DESCRIPTION
added a `refstats` file from the `bbmap` tool `bbsplit`

file in question is from splitting reads across two species

but note that `bbsplit` can technically handle more reference genomes