### PR TITLE
example of zero-division error for sambamba markdup

### DIFF
--- a/data/modules/sambamba/markdup/v0.8.1/paired_end/empty_markdup.txt
+++ b/data/modules/sambamba/markdup/v0.8.1/paired_end/empty_markdup.txt
@@ -1,0 +1,8 @@
+finding positions of the duplicate reads in the file...
+  sorted 0 end pairs
+     and 0 single ends (among them 0 unmatched pairs)
+  collecting indices of duplicate reads...   done in 0 ms
+  found 0 duplicates
+collected list of positions in 0 min 0 sec
+removing duplicates...
+collected list of positions in 0 min 0 sec


### PR DESCRIPTION
This file is an example of a sambamba markdup log file that leads to a zero-division error. Not sure if it is required, but it may be a good idea to have a "negative control" case to address issues like https://github.com/ewels/MultiQC/issues/1654