### PR TITLE
Example for haplocheck

### DIFF
--- a/data/modules/haplocheck/na12878.raw.txt
+++ b/data/modules/haplocheck/na12878.raw.txt
@@ -1,0 +1,2 @@
+"Sample"	"Contamination Status"	"Contamination Level"	"Distance"	"Sample Coverage"	"Overall Homoplasmies"	"Overall Heteroplasmies"	"Major Heteroplasmy Level"	"Minor Heteroplasmy Level"	"Major Haplogroup"	"Major Haplogroup Quality"	"Minor Haplogroup"	"Minor Haplogroup Quality"	"Major Homoplasmies Count"	"Minor Homoplasmies Count"	"Major Heteroplasmies Count"	"Minor Heteroplasmies Count"	"Clusters"
+"NA12878"	"NO"	"ND"	"11"	"126"	"0"	"16"	"0.991"	"0.000"	"H13a1a1a"	"0.796"	"H2a2a1"	"0.500"	"0"	"0"	"13"	"0"	"0.97 (1);0.985 - 0.995 (12);"


### PR DESCRIPTION
Include test data to evaluate the haplocheck module. The test dataset was derived from mtDNA obtained from the NA12878 sample.

`haplocheck --raw --out $prefix $vcf`