### PR TITLE
For running-module-twice FASTQC example, add custom anchors into configs

### DIFF
--- a/data/modules/fastqc/issue_843/multiqc_config.yaml
+++ b/data/modules/fastqc/issue_843/multiqc_config.yaml
@@ -1,11 +1,13 @@
 module_order:
     - fastqc:
         name: 'FastQC (raw)'
+        anchor: "fastqc_trimmed"
         info: 'This section of the report shows FastQC results before adapter trimming.'
         path_filters:
             - '*_fastqc.zip'
     - fastqc:
         name: 'FastQC (trimmed)'
+        anchor: "fastqc_raw"
         info: 'This section of the report shows FastQC results after adapter trimming.'
         target: ''
         path_filters:


### PR DESCRIPTION
To match example in https://multiqc.info/docs/reports/customisation/#running-modules-multiple-times

Ref https://github.com/ewels/MultiQC/issues/2203