### PR TITLE
Test data for hifi_trimmer

### DIFF
--- a/data/modules/hifi_trimmer/hifi_trimmer_sample.json
+++ b/data/modules/hifi_trimmer/hifi_trimmer_sample.json
@@ -1,0 +1,9 @@
+{
+    "summary": {
+        "total_reads_processed": 5,
+        "total_bases_processed": 50316,
+        "total_reads_discarded": 1,
+        "total_reads_trimmed": 3,
+        "total_bases_removed": 14695
+    }
+}

--- a/data/modules/hifi_trimmer/sample1_hifi_trimmer.json
+++ b/data/modules/hifi_trimmer/sample1_hifi_trimmer.json
@@ -1,0 +1,9 @@
+{
+    "summary": {
+        "total_reads_processed": 1000,
+        "total_bases_processed": 15000000,
+        "total_reads_discarded": 50,
+        "total_reads_trimmed": 300,
+        "total_bases_removed": 1200000
+    }
+}

--- a/data/modules/hifi_trimmer/sample1_hifi_trimmer.stats
+++ b/data/modules/hifi_trimmer/sample1_hifi_trimmer.stats
@@ -21,8 +21,8 @@ SN	reads MQ0:	0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
 SN	supplementary alignments:	0
-SN	total length:	150000000
-SN	total first fragment length:	150000000
+SN	total length:	75000000
+SN	total first fragment length:	75000000
 SN	total last fragment length:	0
 SN	bases mapped:	14250000
 SN	bases mapped (cigar):	14250000

--- a/data/modules/hifi_trimmer/sample1_hifi_trimmer.stats
+++ b/data/modules/hifi_trimmer/sample1_hifi_trimmer.stats
@@ -1,0 +1,46 @@
+# This file was produced by samtools stats (1.19+htslib-1.19) and can be plotted using plot-bamstats
+# This file contains statistics for all reads.
+# The command line was:  stats sample1.bam
+# CHK, Checksum	[2]Read Names	[3]Sequences	[4]Qualities
+# CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
+CHK	2e5a6f8c	4a3b2c1d	5d4c3b2a
+# Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
+SN	raw total sequences:	5000
+SN	filtered sequences:	0
+SN	sequences:	5000
+SN	is sorted:	1
+SN	1st fragments:	1000
+SN	last fragments:	0
+SN	reads mapped:	4950
+SN	reads mapped and paired:	0
+SN	reads unmapped:	50
+SN	reads properly paired:	0
+SN	reads paired:	0
+SN	reads duplicated:	0
+SN	reads MQ0:	0
+SN	reads QC failed:	0
+SN	non-primary alignments:	0
+SN	supplementary alignments:	0
+SN	total length:	150000000
+SN	total first fragment length:	150000000
+SN	total last fragment length:	0
+SN	bases mapped:	14250000
+SN	bases mapped (cigar):	14250000
+SN	bases trimmed:	0
+SN	bases duplicated:	0
+SN	mismatches:	5000
+SN	error rate:	3.508772e-04
+SN	average length:	15000
+SN	average first fragment length:	15000
+SN	average last fragment length:	0
+SN	maximum length:	20000
+SN	maximum first fragment length:	20000
+SN	maximum last fragment length:	0
+SN	average quality:	35.0
+SN	insert size average:	0.0
+SN	insert size standard deviation:	0.0
+SN	inward oriented pairs:	0
+SN	outward oriented pairs:	0
+SN	pairs with other orientation:	0
+SN	pairs on different chromosomes:	0
+SN	percentage of properly paired reads (%):	0.0

--- a/data/modules/hifi_trimmer/sample2_hifi_trimmer.json
+++ b/data/modules/hifi_trimmer/sample2_hifi_trimmer.json
@@ -1,0 +1,9 @@
+{
+    "summary": {
+        "total_reads_processed": 1500,
+        "total_bases_processed": 22000000,
+        "total_reads_discarded": 100,
+        "total_reads_trimmed": 450,
+        "total_bases_removed": 2000000
+    }
+}


### PR DESCRIPTION
Here are test data for [hifi_trimmer](https://github.com/sanger-tol/hifi-trimmer), a command-line tool for filtering and trimming extraneous adapter hits from a HiFi read set using a BLAST search against a fasta file of adapter sequences.